### PR TITLE
change the latex text source

### DIFF
--- a/src/showdown-katex.js
+++ b/src/showdown-katex.js
@@ -20,7 +20,7 @@ function renderBlockElements(elements, config, isAsciimath) {
   }
   for (let i = 0, len = elements.length; i < len; i++) {
     const element = elements[i];
-    const input = element.innerHTML;
+    const input = element.textContent;
     const latex = isAsciimath ? asciimathToTex(input) : input;
     const html = katex.renderToString(latex, config);
     element.parentNode.outerHTML = `<span title="${ input }">${ html }</span>`;


### PR DESCRIPTION
change from `.innerhtml` to `.textcontent`. If render from `.innerhtml`, special symbols like "&" would be first rendered by HTML to "&amp;" and then rendered by the KATEX.